### PR TITLE
Redo changes to SHA3 - 256

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the docs [here](https://godoc.org/github.com/rhizomplatform/merkletree).
 
 #### Install
 ```
-go get github.com/rhizomplatform/merkletree
+go get github.com/rhizomplatform/merkletree@master
 ```
 
 #### Example Usage

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 h1:0hQKqeLdqlt5iIwVOBErRisrHJAN57yOiPRQItI20fU=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/merkle_tree.go
+++ b/merkle_tree.go
@@ -5,10 +5,11 @@ package merkletree
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"hash"
+
+	"golang.org/x/crypto/sha3"
 )
 
 //Content represents the data that is stored and verified by the tree. A type that
@@ -80,7 +81,7 @@ func (n *Node) calculateNodeHash() ([]byte, error) {
 
 //NewTree creates a new Merkle Tree using the content cs.
 func NewTree(cs []Content) (*MerkleTree, error) {
-	var defaultHashStrategy = sha256.New
+	var defaultHashStrategy = sha3.New256
 	t := &MerkleTree{
 		hashStrategy: defaultHashStrategy,
 	}

--- a/merkle_tree_test.go
+++ b/merkle_tree_test.go
@@ -6,19 +6,29 @@ package merkletree
 import (
 	"bytes"
 	"crypto/md5"
-	"crypto/sha256"
 	"hash"
 	"testing"
+
+	"golang.org/x/crypto/sha3"
 )
 
-//TestSHA256Content implements the Content interface provided by merkletree and represents the content stored in the tree.
-type TestSHA256Content struct {
+//TestSHAContent implements the Content interface provided by merkletree and represents the content stored in the tree.
+type TestSHAContent struct {
 	x string
 }
 
+const defaultHashStrategyName string = "sha3-256"
+
+var defaultHashStrategy (func() hash.Hash) = sha3.New256
+
+//Generator default generator
+func Generator() hash.Hash {
+	return defaultHashStrategy()
+}
+
 //CalculateHash hashes the values of a TestSHA256Content
-func (t TestSHA256Content) CalculateHash() ([]byte, error) {
-	h := sha256.New()
+func (t TestSHAContent) CalculateHash() ([]byte, error) {
+	h := Generator()
 	if _, err := h.Write([]byte(t.x)); err != nil {
 		return nil, err
 	}
@@ -27,8 +37,8 @@ func (t TestSHA256Content) CalculateHash() ([]byte, error) {
 }
 
 //Equals tests for equality of two Contents
-func (t TestSHA256Content) Equals(other Content) (bool, error) {
-	return t.x == other.(TestSHA256Content).x, nil
+func (t TestSHAContent) Equals(other Content) (bool, error) {
+	return t.x == other.(TestSHAContent).x, nil
 }
 
 //TestContent implements the Content interface provided by merkletree and represents the content stored in the tree.
@@ -71,140 +81,140 @@ var table = []struct {
 }{
 	{
 		testCaseId:          0,
-		hashStrategy:        sha256.New,
-		hashStrategyName:    "sha256",
+		hashStrategy:        defaultHashStrategy,
+		hashStrategyName:    defaultHashStrategyName,
 		defaultHashStrategy: true,
 		contents: []Content{
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hello",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hi",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hey",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hola",
 			},
 		},
-		notInContents: TestSHA256Content{x: "NotInTestTable"},
-		expectedHash:  []byte{95, 48, 204, 128, 19, 59, 147, 148, 21, 110, 36, 178, 51, 240, 196, 190, 50, 178, 78, 68, 187, 51, 129, 240, 44, 123, 165, 38, 25, 208, 254, 188},
+		notInContents: TestSHAContent{x: "NotInTestTable"},
+		expectedHash:  []byte{32, 188, 172, 153, 245, 171, 51, 156, 161, 201, 80, 58, 155, 97, 1, 79, 86, 175, 244, 91, 137, 105, 238, 155, 233, 126, 112, 151, 195, 101, 37, 220},
 	},
 	{
 		testCaseId:          1,
-		hashStrategy:        sha256.New,
-		hashStrategyName:    "sha256",
+		hashStrategy:        defaultHashStrategy,
+		hashStrategyName:    defaultHashStrategyName,
 		defaultHashStrategy: true,
 		contents: []Content{
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hello",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hi",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hey",
 			},
 		},
-		notInContents: TestSHA256Content{x: "NotInTestTable"},
-		expectedHash:  []byte{189, 214, 55, 197, 35, 237, 92, 14, 171, 121, 43, 152, 109, 177, 136, 80, 194, 57, 162, 226, 56, 2, 179, 106, 255, 38, 187, 104, 251, 63, 224, 8},
+		notInContents: TestSHAContent{x: "NotInTestTable"},
+		expectedHash:  []byte{246, 99, 11, 12, 67, 200, 116, 99, 203, 3, 108, 4, 0, 233, 95, 255, 15, 246, 248, 96, 75, 108, 103, 113, 133, 191, 75, 34, 210, 198, 105, 142},
 	},
 	{
 		testCaseId:          2,
-		hashStrategy:        sha256.New,
-		hashStrategyName:    "sha256",
+		hashStrategy:        defaultHashStrategy,
+		hashStrategyName:    defaultHashStrategyName,
 		defaultHashStrategy: true,
 		contents: []Content{
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hello",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hi",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hey",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Greetings",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "Hola",
 			},
 		},
-		notInContents: TestSHA256Content{x: "NotInTestTable"},
-		expectedHash:  []byte{46, 216, 115, 174, 13, 210, 55, 39, 119, 197, 122, 104, 93, 144, 112, 131, 202, 151, 41, 14, 80, 143, 21, 71, 140, 169, 139, 173, 50, 37, 235, 188},
+		notInContents: TestSHAContent{x: "NotInTestTable"},
+		expectedHash:  []byte{136, 215, 127, 182, 176, 143, 79, 68, 202, 214, 24, 78, 62, 145, 30, 204, 179, 170, 168, 186, 229, 63, 48, 193, 209, 165, 91, 208, 45, 255, 197, 224},
 	},
 	{
 		testCaseId:          3,
-		hashStrategy:        sha256.New,
-		hashStrategyName:    "sha256",
+		hashStrategy:        defaultHashStrategy,
+		hashStrategyName:    defaultHashStrategyName,
 		defaultHashStrategy: true,
 		contents: []Content{
-			TestSHA256Content{
+			TestSHAContent{
 				x: "123",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "234",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "345",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "456",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "1123",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "2234",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "3345",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "4456",
 			},
 		},
-		notInContents: TestSHA256Content{x: "NotInTestTable"},
-		expectedHash:  []byte{30, 76, 61, 40, 106, 173, 169, 183, 149, 2, 157, 246, 162, 218, 4, 70, 153, 148, 62, 162, 90, 24, 173, 250, 41, 149, 173, 121, 141, 187, 146, 43},
+		notInContents: TestSHAContent{x: "NotInTestTable"},
+		expectedHash:  []byte{34, 206, 114, 216, 133, 246, 9, 62, 39, 249, 11, 159, 238, 217, 98, 5, 48, 221, 167, 237, 59, 192, 140, 138, 196, 128, 147, 66, 116, 197, 192, 137},
 	},
 	{
 		testCaseId:          4,
-		hashStrategy:        sha256.New,
-		hashStrategyName:    "sha256",
+		hashStrategy:        defaultHashStrategy,
+		hashStrategyName:    defaultHashStrategyName,
 		defaultHashStrategy: true,
 		contents: []Content{
-			TestSHA256Content{
+			TestSHAContent{
 				x: "123",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "234",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "345",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "456",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "1123",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "2234",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "3345",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "4456",
 			},
-			TestSHA256Content{
+			TestSHAContent{
 				x: "5567",
 			},
 		},
-		notInContents: TestSHA256Content{x: "NotInTestTable"},
-		expectedHash:  []byte{143, 37, 161, 192, 69, 241, 248, 56, 169, 87, 79, 145, 37, 155, 51, 159, 209, 129, 164, 140, 130, 167, 16, 182, 133, 205, 126, 55, 237, 188, 89, 236},
+		notInContents: TestSHAContent{x: "NotInTestTable"},
+		expectedHash:  []byte{131, 208, 129, 139, 57, 219, 227, 204, 170, 132, 60, 169, 110, 79, 215, 25, 28, 199, 4, 70, 205, 134, 183, 26, 185, 129, 117, 26, 155, 193, 111, 12},
 	},
 	{
 		testCaseId:          5,
@@ -568,7 +578,7 @@ func TestMerkleTree_MerklePath(t *testing.T) {
 			if err != nil {
 				t.Errorf("[case:%d] error: calculateNodeHash error: %v", table[i].testCaseId, err)
 			}
-			h := sha256.New()
+			h := Generator()
 			for k := 0; k < len(merklePath); k++ {
 				if index[k] == 1 {
 					hash = append(hash, merklePath[k]...)


### PR DESCRIPTION
### Description

 1. Update docs to redirect to our fork 
 1. Changed sha256.New() to sha3.New256()
 1. Changed the expected values in the merkle_tree_test.go files to support the new crypt format SHA3-256
 1. Solved golint warnings

## How to test
- Type the following command line  
```console, shell 
$~ go test ./...
```
__Expected result__
```console, shell 
ok      github.com/cbergoon/merkletree
```

### Checklist

- [x] Code compiles and pass all tests
- [x] No linter warnings (`golangci-lint`)
- [x] <s>Created new</s> Updated tests that fail without these changes
- [x] Updated `README.md` and/or the documentation
- [ ] Updated `AUTHORS` file (`bash -c scripts/update-authors.sh`)